### PR TITLE
adds taskvine to materialize_branches notebook

### DIFF
--- a/materialize_branches.ipynb
+++ b/materialize_branches.ipynb
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "180f4d32-e5c4-42f9-84e8-430034493a55",
+   "id": "45ce7844-00b3-4129-ad5a-1aa64a46bd68",
    "metadata": {
     "tags": []
    },
@@ -36,8 +36,12 @@
     "from coffea.analysis_tools import PackedSelection\n",
     "from coffea import dataset_tools\n",
     "\n",
+    "from functools import partial\n",
+    "import os\n",
     "import time\n",
     "import warnings\n",
+    "    \n",
+    "executor = \"dask\"   # \"dask\" or \"taskvine\"\n",
     "\n",
     "# import utils\n",
     "# utils.plotting.set_style()\n",
@@ -45,19 +49,43 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "NanoAODSchema.warn_missing_crossrefs = False # silences warnings about branches we will not use here\n",
     "\n",
-    "# local: single thread, single worker\n",
-    "from dask.distributed import LocalCluster, Client, progress\n",
-    "# cluster = LocalCluster(n_workers=1, processes=False, threads_per_worker=1)\n",
-    "# client = Client(cluster)\n",
-    "\n",
-    "# for coffea-casa\n",
-    "client = Client(\"tls://localhost:8786\")\n",
-    "\n",
+    "    \n",
     "print(f\"awkward: {ak.__version__}\")\n",
     "print(f\"dask-awkward: {dak.__version__}\")\n",
     "print(f\"uproot: {uproot.__version__}\")\n",
     "print(f\"hist: {hist.__version__}\")\n",
-    "print(f\"coffea: {coffea.__version__}\")"
+    "print(f\"coffea: {coffea.__version__}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f891e515-6bef-4ac3-a72f-9fec2b13c25c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "scheduler_options = {}\n",
+    "\n",
+    "# for coffea-casa\n",
+    "if executor == \"taskvine\":\n",
+    "    from ndcctools.taskvine import DaskVine\n",
+    "    manager = DaskVine(port=8788, ssl=True, name=f\"{os.environ.get('USER', 'noname')}-coffea-casa\")\n",
+    "    vine_scheduler = partial(manager.get,\n",
+    "                             resources={\"cores\": 1, \"disk\": 5000},  #  max 1 core, 5GB of disk per task\n",
+    "                             #  resources_mode=None,   # set to \"fixed\" to kill tasks on resources\n",
+    "                            )\n",
+    "    # change default scheduler\n",
+    "    scheduler_options['scheduler'] = vine_scheduler\n",
+    "else:\n",
+    "    # by default use dask   \n",
+    "    # local: single thread, single worker\n",
+    "    from dask.distributed import LocalCluster, Client, progress\n",
+    "    \n",
+    "    # cluster = LocalCluster(n_workers=1, processes=False, threads_per_worker=1)\n",
+    "    # client = Client(cluster)\n",
+    "    client = Client(\"tls://localhost:8786\")\n"
    ]
   },
   {
@@ -160,7 +188,7 @@
    "source": [
     "%%time\n",
     "# pre-process\n",
-    "samples, _ = dataset_tools.preprocess(fileset, step_size=500_000,uproot_options={\"allow_read_errors_with_report\": True})"
+    "samples, _ = dataset_tools.preprocess(fileset, step_size=500_000,uproot_options={\"allow_read_errors_with_report\": True},**scheduler_options)"
    ]
   },
   {
@@ -197,7 +225,7 @@
     "%%time\n",
     "# execute\n",
     "t0 = time.perf_counter()\n",
-    "((out, report),) = dask.compute(tasks)  # feels strange that this is a tuple-of-tuple\n",
+    "((out, report),) = dask.compute(tasks, **scheduler_options)  # feels strange that this is a tuple-of-tuple\n",
     "t1 = time.perf_counter()\n",
     "\n",
     "print(f\"total time spent in uproot reading data: {ak.sum([v['duration'] for v in report.values()]):.2f} s\")\n",


### PR DESCRIPTION
Tested it using one worker on the same pod as the coffea-casa notebook (dev instance). Preprocess worked, and I killed it after a couple of the root files were processed. 

To switch to taskvine, set `executor = "taskvine"`.   Dask client is the default.