### PR TITLE
feat: add Dask performance report and throughput calculation

### DIFF
--- a/materialize_branches.ipynb
+++ b/materialize_branches.ipynb
@@ -30,7 +30,7 @@
     "import coffea\n",
     "import numpy as np\n",
     "import uproot\n",
-    "from dask.distributed import Client\n",
+    "from dask.distributed import Client, performance_report\n",
     "\n",
     "from coffea.nanoevents import NanoEventsFactory, NanoAODSchema\n",
     "from coffea.analysis_tools import PackedSelection\n",
@@ -225,7 +225,9 @@
     "%%time\n",
     "# execute\n",
     "t0 = time.perf_counter()\n",
-    "((out, report),) = dask.compute(tasks, **scheduler_options)  # feels strange that this is a tuple-of-tuple\n",
+    "\n",
+    "with performance_report(filename=\"dask-report.html\"):\n",
+    "    ((out, report),) = dask.compute(tasks, **scheduler_options)  # feels strange that this is a tuple-of-tuple\n",
     "t1 = time.perf_counter()\n",
     "\n",
     "print(f\"total time spent in uproot reading data: {ak.sum([v['duration'] for v in report.values()]):.2f} s\")\n",
@@ -252,7 +254,12 @@
    "outputs": [],
    "source": [
     "event_rate = out[\"DY\"][\"nevts\"] / (t1-t0)\n",
-    "print(f\"event rate: {event_rate / 1_000:.2f} kHz\")"
+    "print(f\"event rate: {event_rate / 1_000:.2f} kHz\")\n",
+    "\n",
+    "# need uproot>=5.3.2 to get these useful performance stats\n",
+    "read_MB = ak.sum([v['performance_counters']['num_requested_bytes'] for v in report.values()] / 1_000**2\n",
+    "rate_Mbs = read_MB / (t1-t0)\n",
+    "print(f\" - read {read_MB:.2f} MB in {t1-t0:.2f} s -> {rate_Mbs:.2f} MBps (need to scale by x{200/8/rate_Mbs*1000:.0f} to reach 200 Gbps)\")"
    ]
   }
  ],
@@ -275,7 +282,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adding a useful export of the Dask performance report as html, which includes convenient profiling information. Also adding a counter for the total data ingested. This needs testing by someone with permissions on the input files to ensure it works correctly.

cc @Andrew42 